### PR TITLE
Add express route for matches

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,9 +4,11 @@ var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var cors = require('cors');
+
+// ROUTES
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
-var saveMatchRouter = require("./routes/saveMatch");
+var matchesRouter = require("./routes/matchesRouter");
 
 var app = express();
 
@@ -23,8 +25,8 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'client/build')))
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
-app.use('/saveMatch', saveMatchRouter);
+app.use('/', usersRouter);
+app.use('/', matchesRouter);
 
 // Anything that doesn't match the above, send back index.html
 app.get('*', (req, res) => {

--- a/client/src/components/ScoutContent.js
+++ b/client/src/components/ScoutContent.js
@@ -5,9 +5,39 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 
 class ScoutContent extends Component {
+
+  handleSubmit = event => {
+    event.preventDefault()
+    let form = event.target;
+    const data = { 
+      competition: document.getElementById ('formCompetition').value,
+      teamNum: document.getElementById ('formTeamNum').value,
+      matchNum: document.getElementById ('formMatchNum').value
+    };
+
+    fetch('/matches', { 
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    })
+    .then((response) => response.json())
+    .then((data) => {
+      alert(data.message)
+      console.log('Success:', data);
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+    });
+  };
+
   render() {
     return (
-      <Form>
+      <Form
+        onSubmit={this.handleSubmit}
+        className="match-form"
+      >
         <Form.Group className="mt-3" as={Row} controlId="formCompetition">
           <Form.Label column xs="2"></Form.Label>
           <Col xs="6">
@@ -44,11 +74,11 @@ class ScoutContent extends Component {
             <Form.Check custom="true" type="switch" label="" />
           </Col>
         </Form.Group>
+        
+        <Button type="submit" className="btn-lg">Submit form</Button>
 
-        <Button variant="primary" type="submit">
-          Submit
-        </Button>
       </Form>
+
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,16 @@
         "qs": "6.5.2",
         "raw-body": "2.3.3",
         "type-is": "~1.6.16"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "bootstrap": {
@@ -398,11 +408,18 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decamelize": {
@@ -522,6 +539,16 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "fill-range": {
@@ -544,6 +571,16 @@
         "parseurl": "~1.3.2",
         "statuses": "~1.4.0",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "forwarded": {
@@ -916,6 +953,16 @@
         "depd": "~1.1.2",
         "on-finished": "~2.3.0",
         "on-headers": "~1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -1320,6 +1367,16 @@
         "on-finished": "~2.3.0",
         "range-parser": "~1.2.0",
         "statuses": "~1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "serve-static": {
@@ -1478,6 +1535,16 @@
       "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
       "requires": {
         "debug": "^2.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "dependencies": {
     "bootstrap": "^4.4.1",
-    "cookie-parser": "~1.4.4",
+    "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",
-    "debug": "~2.6.9",
+    "debug": "^4.1.1",
     "express": "^4.16.4",
-    "http-errors": "~1.6.3",
-    "morgan": "~1.9.1",
+    "http-errors": "^1.6.3",
+    "morgan": "^1.9.1",
     "nodemon": "^2.0.2",
     "pug": "^2.0.4"
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
+  console.log("root get !!!!!!")
   res.render('index', { title: 'Express' });
 });
 

--- a/routes/matchesRouter
+++ b/routes/matchesRouter
@@ -1,0 +1,18 @@
+var express = require('express');
+var router = express.Router();
+
+router.get('/matches', (req, res) => {
+  res.json({message: 'received'}) /* TODO: Return list of matches for specified competition for display with EDIT/DELETE and NEW buttons */
+})
+
+router.post('/matches', (req, res) => {
+  let params = req.body
+  res.json(
+    { 
+      message: `We saved team ${params.teamNum} match ${params.matchNum} for ${params.competition}`,
+      params
+    }
+  )
+})
+
+module.exports = router;

--- a/routes/saveMatch.js
+++ b/routes/saveMatch.js
@@ -1,8 +1,0 @@
-var express = require("express");
-var router = express.Router();
-
-router.get("/", function(req, res, next) {
-    res.send("Match saved!!");
-})
-
-module.exports=router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -2,7 +2,8 @@ var express = require('express');
 var router = express.Router();
 
 /* GET users listing. */
-router.get('/', function(req, res, next) {
+router.get('/users', function(req, res, next) {
+  console.log("inside users");
   res.send('respond with a resource');
 });
 


### PR DESCRIPTION
**Summary**

We need an API for the web client to call in order to persist data. The first step is to create a proper API endpoint. 

**Details**

We add a route from root called matches (/matches) which accepts a POST.

**Testing**

Clicked the Submit button from the Scout Tab and confirmed the alert had proper data.

**Next Steps**

Add Postgres and save the data. Need to decided if we want to use proper normalization. For example it would be wise to create a table for competitions/etc and use a foreign key.

Also we should rename the Scout tab to "Match". And actually we should provide some navigation. Perhaps from the Match tab we land on page showing a table of all saved matches. There would be Edit/Delete options for each match and a button for "Add New Match" which would take us to the data collection page (which is currently the Scout tab).

Once we have the Postgres infra set up then we can fill up with proper data from the Matches page. And then add more tables and another endpoint for pit scouting.