### PR TITLE
Rename Scout to Match for tab

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,7 +2,7 @@ import React from "react";
 import "./components/TabNav";
 import TabNav from "./components/TabNav";
 import PitContent from "./components/PitContent";
-import ScoutContent from "./components/ScoutContent";
+import MatchContent from "./components/MatchContent";
 import AnalystContent from "./components/AnalystContent";
 import "bootstrap/dist/css/bootstrap.min.css";
 //import 'bootstrap/dist/css/bootstrap.css';
@@ -15,8 +15,8 @@ window.onbeforeunload = event => {
 function RenderTabContent({ selectedTab }) {
   if (selectedTab === "pit") {
     return <PitContent />;
-  } else if (selectedTab === "scout") {
-    return <ScoutContent />;
+  } else if (selectedTab === "match") {
+    return <MatchContent />;
   } else {
     return <AnalystContent />;
   }
@@ -40,7 +40,7 @@ class App extends React.Component {
 
   componentDidMount() {
     this.setState({
-      selectedTab: localStorage.getItem("selectedTab") || "scout"
+      selectedTab: localStorage.getItem("selectedTab") || "match"
     });
   }
 

--- a/client/src/components/MatchContent.js
+++ b/client/src/components/MatchContent.js
@@ -4,7 +4,7 @@ import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 
-class ScoutContent extends Component {
+class MatchContent extends Component {
 
   handleSubmit = event => {
     event.preventDefault()
@@ -82,4 +82,4 @@ class ScoutContent extends Component {
   }
 }
 
-export default ScoutContent;
+export default MatchContent;

--- a/client/src/components/TabNav.js
+++ b/client/src/components/TabNav.js
@@ -9,7 +9,7 @@ class TabNav extends Component {
 
   componentDidMount() {
     this.setState({
-      activeTab: localStorage.getItem("activeTab") || "scout"
+      activeTab: localStorage.getItem("activeTab") || "match"
     });
   }
 
@@ -25,7 +25,7 @@ class TabNav extends Component {
     return (
       <Tabs activeKey={this.state.activeTab} onSelect={this.handleSelect}>
         <Tab eventKey="pit" title="Pit"></Tab>
-        <Tab eventKey="scout" title="Scout"></Tab>
+        <Tab eventKey="match" title="Match"></Tab>
         <Tab eventKey="analyst" title="Analyst"></Tab>
       </Tabs>
     );


### PR DESCRIPTION
**Summary**

We originally named the tab used to collect match data 'Scout' and we are now renaming that to 'Match'. When we called the tab 'Scout' it was confusing because pit scouts are also scouts; we want the match tab to clearly indicate it's data for matches (not pits).

**Tested**

I tested this in my local and my heroku. The tab name looks right and the match data is saved properly in PG.

**Next Steps**

We need to decide navigation. Perhaps this Match tab should land on a page listing all matches with options to Edit/Delete plus a "New Match" button to get to the data-collection page.