### PR TITLE
Add React Router WIP

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { Component } from "react";
 import "./components/TabNav";
 import TabNav from "./components/TabNav";
 import PitContent from "./components/PitContent";
 import MatchContent from "./components/MatchContent";
 import AnalystContent from "./components/AnalystContent";
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+
 import "bootstrap/dist/css/bootstrap.min.css";
 //import 'bootstrap/dist/css/bootstrap.css';
 import "./App.css";
@@ -27,17 +29,11 @@ window.onunload = event => {
   window.scrollTo(0, 0);
 };
 
-class App extends React.Component {
+class App extends Component {
   state = {
     apiResponse: "",
     selectedTab: ""
   };
-
-  callAPI() {
-    fetch("/saveMatch")
-      .then(res => res.text())
-      .then(res => this.setState({ apiResponse: res }));
-  }
 
   componentDidMount() {
     this.setState({
@@ -58,13 +54,34 @@ class App extends React.Component {
     return (
       <div className="App">
         <TabNav
-          tabHandler={this.handleTabSelect}
           onClick={this.handleTabSelect}
         />
-        <RenderTabContent selectedTab={this.state.selectedTab} />
+        <Router>
+          <Switch>
+            <Route path="/pits" component={PitNavigation} />
+            <Route path="/matches" component={MatchContent} />
+            <Route path="/analystHome" component={AnalystContent} />
+          </Switch>
+        </Router>
       </div>
     );
   }
+
+//   render() {
+//     const App = () => (
+//       <div>
+//         <Switch>
+//           <Route exact path='/' component={TabNav}/>
+//         </Switch>
+//       </div>
+//     )
+//     return (
+//       <Switch>
+//         <App/>
+//       </Switch>
+//     )
+//   }
+
 }
 
 export default App;

--- a/client/src/components/MatchContent.js
+++ b/client/src/components/MatchContent.js
@@ -3,8 +3,11 @@ import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import { Link } from 'react-router-dom';
+
 
 class MatchContent extends Component {
+
   handleSubmit = event => {
     event.preventDefault();
     const data = {
@@ -13,7 +16,7 @@ class MatchContent extends Component {
       matchNum: document.getElementById("formMatchNum").value
     };
 
-    fetch("/matches", {
+    fetch("/match", {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
@@ -31,8 +34,24 @@ class MatchContent extends Component {
   };
 
   render() {
-    return (
+    const matches = [
+      {name: 'jonMatch', id: 123},
+      {name: 'SharonMatch', id: 124},
+      {name: 'FonMatch', id: 125},
+      {name: 'GonMatch', id: 126},
+      {name: 'HonMatch', id: 127}
+    ];
+
+    const listItems = matches.map((match) =>
+        <li key={match.id}>
+              <Link to={`/matches/${match.id}`}>{match.name}</Link>
+        </li>
+    );
+
+    return (      
       <Form onSubmit={this.handleSubmit} className="match-form">
+        <ul>{listItems}</ul>
+
         <Form.Group className="mt-3" as={Row} controlId="formCompetition">
           <Form.Label column xs="2"></Form.Label>
           <Col xs="6">

--- a/client/src/components/TabNav.js
+++ b/client/src/components/TabNav.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Tabs from "react-bootstrap/Tabs";
-import Tab from "react-bootstrap/Tab";
+import Nav from "react-bootstrap/Nav";
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 class TabNav extends Component {
   state = {
@@ -23,11 +24,20 @@ class TabNav extends Component {
 
   render() {
     return (
-      <Tabs activeKey={this.state.activeTab} onSelect={this.handleSelect}>
-        <Tab eventKey="pit" title="Pit"></Tab>
-        <Tab eventKey="match" title="Match"></Tab>
-        <Tab eventKey="analyst" title="Analyst"></Tab>
-      </Tabs>
+      <Router>
+        <Nav variant="tabs" defaultActiveKey="/">
+          <Nav.Item>
+            <Nav.Link href="/pits">Pit</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link href="/matches">Match</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link href="/analystHome">Analyst</Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Router>
+
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -686,6 +686,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -698,6 +703,27 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "http-errors": {
       "version": "1.6.3",
@@ -863,6 +889,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -979,6 +1010,16 @@
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
         "mime-db": "1.43.0"
+      }
+    },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
       }
     },
     "minimatch": {
@@ -1446,6 +1487,47 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-router": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.1.2",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-transition-group": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.3.tgz",
@@ -1499,6 +1581,11 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "right-align": {
       "version": "0.1.3",
@@ -1666,6 +1753,16 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -1794,6 +1891,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "nodemon": "^2.0.2",
     "pg": "^7.17.1",
     "pug": "^2.0.4",
-    "react-bootstrap-table-next": "^3.3.3"
+    "react-bootstrap-table-next": "^3.3.3",
+    "react-router-dom": "^5.1.2"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,15 @@
 var express = require("express");
-var router = express.Router();
+const path = require('path');
+
+const app = express();
+
+//app.use('/api');
+app.use(express.static(path.join(__dirname, 'api')));
 
 /* GET home page. */
-router.get("/", function(req, res, next) {
+app.get("/", function(req, res, next) {
   console.log("root get !!!!!!");
   res.render("index", { title: "Express" });
 });
 
-module.exports = router;
+module.exports = app;

--- a/routes/matchesRouter.js
+++ b/routes/matchesRouter.js
@@ -2,13 +2,29 @@ var express = require('express');
 var router = express.Router();
 const db = require('../db');
 
-router.get('/matches', (req, res) => {
-  res.json({
-    message: 'received'
-  }); /* TODO: Return list of matches for specified competition for display with EDIT/DELETE and NEW buttons */
+// router.get('/matches', (req, res) => {
+//   res.json({
+//     message: 'received'
+//   }); /* TODO: Return list of matches for specified competition for display with EDIT/DELETE and NEW buttons */
+// });
+
+router.get('/match', (req, res) => {
+  let params = req.body;
+  // TODO: Rename to singular and add param for matchId (and add another route for /competition/:sn/match for all competiton matches)
+  const getMatchesQuery =
+    'SELECT c.short_name, t.team_num, m.match_num FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id';
+
+  db.query(getMatchesQuery, null)
+    .then(data => {
+      res.json({
+        matchData: data.rows
+      });
+    })
+    .catch(e => console.error(e.stack));
 });
 
-router.post('/matches', (req, res) => {
+// HELP - api/matches does not work, /matches works.. something not right in express app
+router.post('/match', (req, res) => {
   let params = req.body;
 
   const addMatchQuery =


### PR DESCRIPTION
**Summary**

It would be helpful to create restful client routes. This change is just the first step. It sets up the infra and allows us to build on it. Notice that the URL changes when you click into a Tab. These links can be used to navigate our single page application and also can be helpful in placing links in buttons/etc (such as the "Edit" button on the pit report list page). Also these links can be used like any api (from command line curls or browser urls) to get the actual data (json, cvs, whatever) although this will not really be necessary since we will be adding Export button to each report-list page but I still mention it here as a plus.

This is still a Work In Progress. But a PR makes sense so that nothing is lost and we can hopefully avoid painful merge conflicts. 

**Details**

This change sets up the whole app but I've not touched any pit code. For now I will focus on match. Once that is all polished up we can apply to pit (or at same time, no reason to wait really).

**Testing**

I clicked on each tab from the home page and confirmed that it takes me to the right spot which works and that the proper URL extension was made. (The Match page looks weird, don't worry about that for now)

**Spec**

We should review the Issue added to this repo for our rest api. This is the first step.

**Next Step**

I will add the navigation page for matches similar to Pit navigation and will use the routes to get from navigation page to the data collection page. It would help if we could clean up the database design. Please review the Issue for competition-team mapping proposal.
