### PR TITLE
Add restful express route and wire up competition dropdown in match navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ var usersRouter = require('./routes/users');
 var matchesRouter = require('./routes/matchesRouter');
 var pitNavRouter = require('./routes/pitNavRouter');
 var pitFormRouter = require('./routes/pitFormRouter');
+var competitionRouter = require('./routes/competitionRouter');
 
 var app = express();
 
@@ -28,9 +29,10 @@ app.use(express.static(path.join(__dirname, 'client/build')));
 
 app.use('/', indexRouter);
 app.use('/', usersRouter);
-app.use('/', matchesRouter);
+app.use('/api', matchesRouter);
 app.use('/', pitNavRouter);
 app.use('/', pitFormRouter);
+app.use('/', competitionRouter);
 
 // Anything that doesn't match the above, send back index.html
 app.get('*', (req, res) => {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import "./components/TabNav";
 import TabNav from "./components/TabNav";
 import PitContent from "./components/PitContent";
-import MatchContent from "./components/MatchContent";
+import MatchReportList from "./components/MatchReportList";
 import AnalystContent from "./components/AnalystContent";
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
@@ -19,7 +19,7 @@ function RenderTabContent({ selectedTab }) {
   if (selectedTab === "pit") {
     return <PitNavigation />;
   } else if (selectedTab === "match") {
-    return <MatchContent />;
+    return <MatchReportList />;
   } else {
     return <AnalystContent />;
   }
@@ -59,7 +59,7 @@ class App extends Component {
         <Router>
           <Switch>
             <Route path="/pits" component={PitNavigation} />
-            <Route path="/matches" component={MatchContent} />
+            <Route path="/matches" component={MatchReportList} />
             <Route path="/analystHome" component={AnalystContent} />
           </Switch>
         </Router>

--- a/client/src/components/MatchReportList.js
+++ b/client/src/components/MatchReportList.js
@@ -1,0 +1,106 @@
+import React, { Component } from "react";
+import { Form, Dropdown } from "react-bootstrap"
+import { Link } from 'react-router-dom';
+
+class MatchReportList extends Component {
+    state = {
+        competition: '',
+        competitions: [],
+        rows: [],
+      };
+
+    getMatchReportListForCompetition = competition => {
+      this.setState({
+        competition: competition
+      });
+      fetch(`/api/competitions/${competition}/matches`)
+      .then(response => response.json())
+      .then(data => {
+        console.log("DATA", data)
+      })
+
+      // fetch(`/api/competitions/${competition}/matches`, {
+      //     method: "POST",
+      //     headers: {
+      //       "Content-Type": "application/json"
+      //     },
+      //     body: JSON.stringify(competition)
+      //   })
+      //   .then(ress => {
+      //     console.log('ress', ress)
+      //     return ress
+      //   })
+      //     .then(response => response.json())
+      //     .then(data => {
+      //       this.setState({ rows: data.matchList });
+      //       console.log("Success:", data);
+      //     })
+      //     .catch(error => {
+      //       console.error("Error:", error);
+      //     });
+    };
+
+    // handleCompetitionSelection = event => {
+    //     this.setState({
+    //         competition: event
+    //     });
+    // }
+
+    componentDidMount() {
+        fetch("/competitions")
+            .then(response => response.json())
+            .then(data => {
+              this.setState({ competitions: data.competitions });
+              console.log("Success:", data);
+            })
+            .catch(error => {
+              console.error("Error:", error);
+            });
+    }
+
+    render() {
+      const matches = [
+        {name: 'FooMatch', id: 123},
+        {name: 'SharonMatch', id: 124},
+        {name: 'FonMatch', id: 125},
+        {name: 'GonMatch', id: 126},
+        {name: 'HonMatch', id: 127}
+      ];
+      const competitions = [
+        {name: 'FooMatch' },
+        {name: 'ShoMatch' },
+        {name: 'FooMatch' },
+        {name: 'FooMatch' }
+      ];
+  
+        const listItems = matches.map((match) =>
+            <li key={match.id}>
+                  <Link to={`/matches/${match.id}`}>{match.name}</Link>
+            </li>
+        );
+
+        const competitionItems = this.state.competitions.map((competition) =>
+          <Dropdown.Item eventKey={competition.shortname} value={competition.competitionid}>{competition.shortname}</Dropdown.Item>
+        );
+    
+        return (   
+            <Form onSubmit={this.handleSubmit} className="matches-form">
+                <ul>{listItems}</ul>
+          
+                <Dropdown focusFirstItemOnShow={true} onSelect={this.getMatchReportListForCompetition}>
+                  <Dropdown.Toggle variant="success" id="dropdown-basic">
+                    {this.state.competition || 'Select One'}
+                  </Dropdown.Toggle>
+
+                  <Dropdown.Menu>
+                    {competitionItems}
+                  </Dropdown.Menu>
+                </Dropdown>
+
+            </Form> 
+
+        );
+    }
+}
+
+export default MatchReportList;

--- a/routes/competitionRouter.js
+++ b/routes/competitionRouter.js
@@ -1,0 +1,18 @@
+var express = require('express');
+var router = express.Router();
+const db = require('../db');
+
+router.get('/competitions', (req, res) => {
+  const getAllCompetitionsQuery = 'SELECT short_name as shortname, competition_id as competitionid FROM competition';
+
+  db.query(getAllCompetitionsQuery)
+    .then(data => {
+      let competitions = data.rows
+      res.json({
+        competitions
+      });
+    })
+    .catch(e => console.error(e.stack));
+});
+
+module.exports = router;

--- a/routes/matchesRouter.js
+++ b/routes/matchesRouter.js
@@ -2,28 +2,38 @@ var express = require('express');
 var router = express.Router();
 const db = require('../db');
 
-// router.get('/matches', (req, res) => {
-//   res.json({
-//     message: 'received'
-//   }); /* TODO: Return list of matches for specified competition for display with EDIT/DELETE and NEW buttons */
-// });
 
-router.get('/match', (req, res) => {
+router.get('/competitions/:shortName/matches', (req, res) => {
+  const getMatchesForCompetitionQuery =
+  'SELECT t.team_num, m.match_num FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id WHERE c.short_name = $1';
+  const getMatchesForCompetitionValues = [ req.params.shortName ];
+  
+  db.query(getMatchesForCompetitionQuery, getMatchesForCompetitionValues)
+  .then(data => {
+    res.json({
+      matchList: data.rows
+    });
+  })
+  .catch(e => console.error(e.stack));
+})
+
+router.post('/competitions/:id/matches', (req, res) => {
+  console.log('POSTED')
   let params = req.body;
-  // TODO: Rename to singular and add param for matchId (and add another route for /competition/:sn/match for all competiton matches)
-  const getMatchesQuery =
-    'SELECT c.short_name, t.team_num, m.match_num FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id';
+  console.log("params",params);
+  const getMatchesForCompetitionQuery =
+    'SELECT t.team_num, m.match_num FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id WHERE c.short_name = $1';
+  const getMatchesForCompetitionValues = [ params.shortname ];
 
-  db.query(getMatchesQuery, null)
+  db.query(getMatchesForCompetitionQuery, getMatchesForCompetitionValues)
     .then(data => {
       res.json({
-        matchData: data.rows
+        matchList: data.rows
       });
     })
     .catch(e => console.error(e.stack));
 });
 
-// HELP - api/matches does not work, /matches works.. something not right in express app
 router.post('/match', (req, res) => {
   let params = req.body;
 


### PR DESCRIPTION
**Summary**

This is a WORK IN PROGRESS but I didn't want to hold up other developers so they can see how the react routing and express routing are working to wire up the competition drop down and reach match data.

**Details**

Only the match stuff was change, no changes to pit at this time.  

I added a new router for competition so we can get all competitions to use in drop-down. Upon drop-down selection we call out to /api/competitions/:competitionShortName/matches. Proper data from database is returned (but not yet displayed in the app screen).

**Testing**

The express server can be tested via curl or the browser explicitly:

url -d '{"shortname":"HVR", "competitionid":"1"}' -H "Content-Type: applicon/json" -X POST http://localhost:5000/api/competitions/HVR/matches

Also the web app can be used. Right now that app screen looks messy. This will be cleaned in a future PR.

**Next Steps**

So many. Change competition route to use /api (and eventually pit and all express routes).  Add a display table to the match navigation page listing all matches for the selected competition. Make the match endpoint restful and place it in the link/button on each row of the match list on the navigation screen so that the user can edit that match. Add a "new match" button on the navigation page. General cleanup of the page.