### PR TITLE
add match display table

### DIFF
--- a/client/src/components/MatchReportList.js
+++ b/client/src/components/MatchReportList.js
@@ -1,12 +1,14 @@
 import React, { Component } from "react";
 import { Form, Dropdown } from "react-bootstrap"
 import { Link } from 'react-router-dom';
+import BootstrapTable from 'react-bootstrap-table-next';
 
 class MatchReportList extends Component {
     state = {
         competition: '',
         competitions: [],
-        rows: [],
+        matches: [],
+        columns: [{}]
       };
 
     getMatchReportListForCompetition = competition => {
@@ -16,35 +18,15 @@ class MatchReportList extends Component {
       fetch(`/api/competitions/${competition}/matches`)
       .then(response => response.json())
       .then(data => {
-        console.log("DATA", data)
+        console.log("DATA", data);
+        this.setState({
+          matches: data.matchList
+        })
+        this.setState({
+          columns: this.getMatchFields()
+        })
       })
-
-      // fetch(`/api/competitions/${competition}/matches`, {
-      //     method: "POST",
-      //     headers: {
-      //       "Content-Type": "application/json"
-      //     },
-      //     body: JSON.stringify(competition)
-      //   })
-      //   .then(ress => {
-      //     console.log('ress', ress)
-      //     return ress
-      //   })
-      //     .then(response => response.json())
-      //     .then(data => {
-      //       this.setState({ rows: data.matchList });
-      //       console.log("Success:", data);
-      //     })
-      //     .catch(error => {
-      //       console.error("Error:", error);
-      //     });
     };
-
-    // handleCompetitionSelection = event => {
-    //     this.setState({
-    //         competition: event
-    //     });
-    // }
 
     componentDidMount() {
         fetch("/competitions")
@@ -56,26 +38,35 @@ class MatchReportList extends Component {
             .catch(error => {
               console.error("Error:", error);
             });
+
+        // Default the table to some competition TODO: Use database current competition flag
+        // fetch(`/api/competitions/HVR/matches`)
+        //   .then(response => response.json())
+        //   .then(data => {
+        //     // this.state.matches = data.matchList;
+        //     this.setState({matches: data.matchList})
+        //     this.getMatchFields()
+        //     console.log("DATA", this.state.matches);
+
+        // })
+    }
+
+    getMatchFields () {
+      if (this.state.matches.length === 0) return []
+      let columns = Object.keys(this.state.matches[0]).map(key => {
+        return {
+          dataField: key,
+          text: key.toUpperCase()
+        }
+      })
+      console.log('COLUMNS ARE', columns)
+      return columns;
     }
 
     render() {
-      const matches = [
-        {name: 'FooMatch', id: 123},
-        {name: 'SharonMatch', id: 124},
-        {name: 'FonMatch', id: 125},
-        {name: 'GonMatch', id: 126},
-        {name: 'HonMatch', id: 127}
-      ];
-      const competitions = [
-        {name: 'FooMatch' },
-        {name: 'ShoMatch' },
-        {name: 'FooMatch' },
-        {name: 'FooMatch' }
-      ];
-  
-        const listItems = matches.map((match) =>
+        const matchItems = this.state.matches.map((match) =>
             <li key={match.id}>
-                  <Link to={`/matches/${match.id}`}>{match.name}</Link>
+                  <Link to={`/matches/${match.matchid}`}>{match.teamnum}</Link>
             </li>
         );
 
@@ -85,17 +76,29 @@ class MatchReportList extends Component {
     
         return (   
             <Form onSubmit={this.handleSubmit} className="matches-form">
-                <ul>{listItems}</ul>
+                <ul>{matchItems}</ul>
           
                 <Dropdown focusFirstItemOnShow={true} onSelect={this.getMatchReportListForCompetition}>
                   <Dropdown.Toggle variant="success" id="dropdown-basic">
                     {this.state.competition || 'Select One'}
                   </Dropdown.Toggle>
-
                   <Dropdown.Menu>
                     {competitionItems}
                   </Dropdown.Menu>
                 </Dropdown>
+ 
+                <div>
+                <BootstrapTable
+                  stripped
+                  hover
+                  keyField='matchid'
+                  //rowStyle={this.state.style}
+                  bordered
+                  bootstrap4
+                  data={this.state.matches}
+                  columns={this.state.columns}
+                />
+                </div>
 
             </Form> 
 

--- a/routes/matchesRouter.js
+++ b/routes/matchesRouter.js
@@ -5,7 +5,7 @@ const db = require('../db');
 
 router.get('/competitions/:shortName/matches', (req, res) => {
   const getMatchesForCompetitionQuery =
-  'SELECT t.team_num, m.match_num FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id WHERE c.short_name = $1';
+  'SELECT m.match_id as matchid, t.team_num as teamnum, m.match_num as matchnum FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id WHERE c.short_name = $1';
   const getMatchesForCompetitionValues = [ req.params.shortName ];
   
   db.query(getMatchesForCompetitionQuery, getMatchesForCompetitionValues)
@@ -21,11 +21,11 @@ router.post('/competitions/:id/matches', (req, res) => {
   console.log('POSTED')
   let params = req.body;
   console.log("params",params);
-  const getMatchesForCompetitionQuery =
-    'SELECT t.team_num, m.match_num FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id WHERE c.short_name = $1';
-  const getMatchesForCompetitionValues = [ params.shortname ];
+  const getMatchesForCompetitionIdQuery =
+    'SELECT t.team_num as teamnum, m.match_num as matchnum FROM match m INNER JOIN team t ON t.team_id=m.team_id INNER JOIN competition c ON c.competition_id=m.competition_id WHERE c.short_name = $1';
+  const getMatchesForCompetitionIdValues = [ params.shortname ];
 
-  db.query(getMatchesForCompetitionQuery, getMatchesForCompetitionValues)
+  db.query(getMatchesForCompetitionIdQuery, getMatchesForCompetitionIdValues)
     .then(data => {
       res.json({
         matchList: data.rows


### PR DESCRIPTION
**Summary**

We use a restful express endpoint to get all match data for a given competition and display in a BootstrapTable.

**Details**

The page still needs work. I will remove the id column and the debug links (they are just to demonstrate the id and how it will be used to reach an edit page for a selected match) and of course a "add match" button.

**Testing**

This was tested on my laptop to ensure the match data (dummy data in my local db) is displayed in a table.
