### PR TITLE
Add is_current awareness to competition dropdown in match nav 

### DIFF
--- a/routes/competitionRouter.js
+++ b/routes/competitionRouter.js
@@ -3,7 +3,7 @@ var router = express.Router();
 const db = require('../db');
 
 router.get('/competitions', (req, res) => {
-  const getAllCompetitionsQuery = 'SELECT short_name as shortname, competition_id as competitionid FROM competition';
+  const getAllCompetitionsQuery = 'SELECT short_name as shortname, is_current as iscurrent, competition_id as competitionid FROM competition';
 
   db.query(getAllCompetitionsQuery)
     .then(data => {

--- a/routes/matchesRouter.js
+++ b/routes/matchesRouter.js
@@ -22,7 +22,7 @@ router.post('/competitions/:id/matches', (req, res) => {
   let params = req.body;
   console.log("params",params);
   const getMatchesForCompetitionIdQuery =
-    'SELECT t.team_num as teamnum, m.match_num as matchnum FROM match m INNER JOIN comp_team_mapping mapping on mapping.mapping_id=m.mapping_id INNER JOIN team t ON t.team_id=mapping.team_id INNER JOIN competition c ON c.competition_id=mapping.competition_id WHERE c.short_name = $1';
+    'SELECT t.team_num as teamnum, m.match_num as matchnum, m.scout_name as scoutname, m.report_status as reportstatus FROM match m INNER JOIN comp_team_mapping mapping on mapping.mapping_id=m.mapping_id INNER JOIN team t ON t.team_id=mapping.team_id INNER JOIN competition c ON c.competition_id=mapping.competition_id WHERE c.short_name = $1';
   const getMatchesForCompetitionIdValues = [ params.shortname ];
 
   db.query(getMatchesForCompetitionIdQuery, getMatchesForCompetitionIdValues)


### PR DESCRIPTION
**Summary**

This change sets the default value of the competition drop-down in the match navigation component based on which competition is set in the database to be is_current. This default is set when the component loads and then immediately fetches the matches for that competition to be displayed in the table.

**Details**

I chained the two fetches (competition and matches) to ensure synch behavior. Javascript fetches are async so we would possibly get into the situation (at competition where cellular connections are slower) where the match fetch comes before the competition fetch. By chaining we can avoid this possible bug.

**Testing**

I tested on my local to make sure default is set correctly and user can still choose other competitions with proper table refresh.

**Next Steps**

I still want to clean up the casing of the variable names but the main next step is to make the rows clickable so the match data component loads. I will play with making the whole row clickable which may be easier on smaller mobile devices (rather than a button) and we can see how it works.  