### PR TITLE
Navigate from match table row to content

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,6 +10,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 //import 'bootstrap/dist/css/bootstrap.css';
 import './App.css';
 import PitNavigation from './components/PitNavigation';
+import MatchContent from './components/MatchContent';
 
 function RenderTabContent({ selectedTab }) {
   if (selectedTab === 'pit') {
@@ -53,6 +54,8 @@ class App extends Component {
           <TabNav onClick={this.handleTabSelect} />
           <Switch>
             <Route path='/pits' exact component={PitNavigation} />
+            <Route path='/matches/:matchId/edit' component={MatchContent} />
+            <Route path='/matches/new' component={MatchContent} />
             <Route path='/matches' component={MatchReportList} />
             <Route path='/analystHome' component={AnalystContent} />
             <Route

--- a/client/src/components/MatchContent.js
+++ b/client/src/components/MatchContent.js
@@ -8,6 +8,17 @@ import { Link } from 'react-router-dom';
 
 class MatchContent extends Component {
 
+  state = {
+    paramMatchId: ''
+  }
+
+  componentDidMount() {
+    console.log("Entered match content");
+    console.log(this.props);
+    console.log(this.props.match.params.matchId);
+    this.setState({ paramMatchId: this.props.match.params.matchId });
+  }
+
   handleSubmit = event => {
     event.preventDefault();
     const data = {

--- a/client/src/components/MatchReportList.js
+++ b/client/src/components/MatchReportList.js
@@ -65,6 +65,7 @@ class MatchReportList extends Component {
     ];
   }
 
+
   render() {
     const matchItems = this.state.matches.map(match => (
       <li key={match.id}>
@@ -81,11 +82,17 @@ class MatchReportList extends Component {
       </Dropdown.Item>
     ));
 
+    const rowEvents = {
+      onClick: (e, row, rowIndex) => {
+        console.log(`clicked on row with index: ${rowIndex}`);
+        console.log(`  the row is: `, row);
+        this.props.history.push(`/matches/${row.matchid}/edit`);
+      }
+    };
+
     return (
       <Form onSubmit={this.handleSubmit} className='matches-form'>
         <ul>{matchItems}</ul>
-
-        <div>{this.state.competition}</div>
 
         <Dropdown
           focusFirstItemOnShow={true}
@@ -105,11 +112,14 @@ class MatchReportList extends Component {
             //rowStyle={this.state.style}
             bordered
             bootstrap4
+            keyField='id'
             data={this.state.matches.map(m => {
-              return { teamnum: m.teamnum, matchnum: m.matchnum };
+              return { matchid: m.matchid, teamnum: m.teamnum, matchnum: m.matchnum };
             })}
             columns={this.state.columns}
+            rowEvents={ rowEvents }
           />
+
         </div>
       </Form>
     );


### PR DESCRIPTION
**Summary**

We want the user to be able to touch a row of the match list table and go to the match data for editing. (Later we will restrict this functionality to users with admin role or perhaps let user view content but restrict the save/update button)

**Details**

We have the matchId from the database rows returned to fill the table so we simply use that in a restful /matches/:matchId/edit React Router.

**Testing**

Clicking a row of the match table takes us to the content with a console log verifying that match id has been successfully parsed from the URL params.

**Next steps**

We can fetch the match data from the database and populate the fields for the user. Need to fix to use new/better express restful api and display-only competition (a non-editable fields) and maybe ditto for team name and match number (let's check with scouting team).

And we need to add a "New" button on top of the match list table so the user can add new match reports.