### PR TITLE
Fix login page issue, make it more RESTful.

### DIFF
--- a/client/src/components/Logout.js
+++ b/client/src/components/Logout.js
@@ -6,7 +6,9 @@ class Logout extends Component {
   static contextType = AuthContext;
 
   componentDidMount() {
-    fetch('/logout').then((response) => {
+    fetch('/logout', {
+      method: 'DELETE'
+    }).then((response) => {
       this.context.logOutUser();
     });
   }

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -13,10 +13,6 @@ router.get('/api/isLoggedIn', (req, res, next) => {
   }
 });
 
-router.get('/login', (req, res, next) => {
-  res.render('login');
-});
-
 router.post('/login',
   passport.authenticate('local', {
     failWithError: true
@@ -34,9 +30,9 @@ router.post('/login',
   }
 );
 
-router.get('/logout', (req, res, nex) => {
+router.delete('/logout', (req, res, nex) => {
   req.logout();
-  res.redirect('/');
+  res.send(200);
 });
 
 module.exports = router;


### PR DESCRIPTION
Addresses concerns in Issue #36 and makes the logout more RESTful...

I didn't test in Heroku per se, but was able to reproduce locally by using `npm run build` in the client folder to build a production version of the assets, and then just running the express server on the backend, so I fixed it based on that. It should work the same as Heroku, the issue was locally we have the front-end app running on port 3000 and intercepting everything, without it direct requests to /login were going to the server-side login page I used when first doing the implementation.

I also made logout more RESTful because why not.