### PR TITLE
Only redirect to /login after checking login satus.

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,9 +39,11 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use(express.static(path.join(__dirname, 'client/build')));
 
-app.use(ensureLoggedIn);
 
 app.use('/', authenticationRouter);
+
+app.use(ensureLoggedIn);
+
 app.use('/', indexRouter);
 app.use('/', usersRouter);
 app.use('/api', matchesRouter);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -84,7 +84,8 @@ const AdminRoute = ({ component: Component, ...rest }) => {
 
 class App extends Component {
   state = {
-    apiResponse: ''
+    apiResponse: '',
+    loaded: false
   };
 
   constructor(props) {
@@ -97,63 +98,82 @@ class App extends Component {
       if (response.ok) {
         response.json().then(user => {
           this.authProvider.current.logInUser(user);
+          this.setState({ loaded: true });
         });
       } else {
         this.authProvider.current.logOutUser();
+        this.setState({ loaded: true });
       }
     });
   }
 
+  loadingApp() {
+    return (<p>Loading...</p>)
+  }
+
+  loadedApp() {
+    return (
+      <Switch>
+        <ProtectedRoute path='/' exact component={Home} />
+        <ProtectedRoute path='/pits' exact component={PitNavigation} />
+        <AdminRoute
+          path='/matches/:competition/:team/:matchNum/'
+          exact component={MatchContent}
+        />
+        <ProtectedRoute
+          path='/matches/new'
+          exact
+          component={MatchContent}
+        />
+        <ProtectedRoute
+          path='/matches'
+          exact
+          component={MatchReportList}
+        />
+        <ProtectedRoute
+          path='/supers/:competition'
+          exact
+          component={SuperScoutContent}
+        />
+        <ProtectedRoute path='/analystHome' component={AnalystContent} />
+        <ProtectedRoute
+          path='/pits/:competition/:team'
+          exact
+          component={PitContent}
+        />
+        <ProtectedRoute path='/data' exact exact component={Data} />
+        <ProtectedRoute
+          path='/data/:competition'
+          exact
+          component={Data}
+        />
+        <ProtectedRoute
+          exact
+          path='/data/:competition/:team/:dataType(match|pit)?'
+          component={Data}
+        />
+        <Route path='/login' component={Login} />
+        <Route path='/logout' component={Logout} />
+        <Route component={Home} />
+      </Switch>
+    )
+  }
+
   render() {
+    let app;
+
+    if (this.state.loaded) {
+      app = this.loadedApp()
+    } else {
+      app = this.loadingApp()
+    }
+
     return (
       <AuthProvider ref={this.authProvider}>
         <div className='App'>
           <Router>
             <TabNav />
-            <Switch>
-              <ProtectedRoute path='/' exact component={Home} />
-              <ProtectedRoute path='/pits' exact component={PitNavigation} />
-              <AdminRoute
-                path='/matches/:competition/:team/:matchNum/'
-                exact
-                component={MatchContent}
-              />
-              <ProtectedRoute
-                path='/matches/new'
-                exact
-                component={MatchContent}
-              />
-              <ProtectedRoute
-                path='/matches'
-                exact
-                component={MatchReportList}
-              />
-              <ProtectedRoute
-                path='/supers/:competition'
-                exact
-                component={SuperScoutContent}
-              />
-              <ProtectedRoute path='/analystHome' component={AnalystContent} />
-              <ProtectedRoute
-                path='/pits/:competition/:team'
-                exact
-                component={PitContent}
-              />
-              <ProtectedRoute path='/data' exact exact component={Data} />
-              <ProtectedRoute
-                path='/data/:competition'
-                exact
-                component={Data}
-              />
-              <ProtectedRoute
-                exact
-                path='/data/:competition/:team/:dataType(match|pit)?'
-                component={Data}
-              />
-              <Route path='/login' component={Login} />
-              <Route path='/logout' component={Logout} />
-              <Route component={Home} />
-            </Switch>
+            { app }
           </Router>
         </div>
       </AuthProvider>

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -3,7 +3,7 @@ var router = express.Router();
 var passport = require('passport');
 
 router.get('/api/isLoggedIn', (req, res, next) => {
-  if (req.user !== null) {
+  if (typeof req.user !== 'undefined' && req.user !== null) {
     res.json({
       username: req.user.username,
       role: req.user.role
@@ -31,7 +31,10 @@ router.post('/login',
 );
 
 router.delete('/logout', (req, res, nex) => {
-  req.logout();
+  if (typeof req.user !== 'undefined' && req.user !== null) {
+    req.logout();
+  }
+
   res.send(200);
 });
 


### PR DESCRIPTION
This should address login issue #39 . Basically, the ProtectedRoute component won't be rendered until after we've checked login state, so we won't send the user to /login until after we've checked if they are logged in. This does lead to a very slight delay where the app is "loading", but it should be a better experience overall.

We do still need more error handling if your session expires and you make an AJAX call, we don't handle that and send the user back to login. When the user sees that data doesn't load for them, they have to refresh, then we'll check login state, and send them to the login page... But one issue at a time.

I'm not a huge fan of having all of the router switch in a function, if anyone is open to better ideas feel free to chime in.