### PR TITLE
First pass at Pick Lists for single teams.

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ var usersRouter = require('./routes/users');
 var matchesRouter = require('./routes/matchesRouter');
 var pitNavRouter = require('./routes/pitNavRouter');
 var pitFormRouter = require('./routes/pitFormRouter');
+var pickListsRouter = require('./routes/pickListsRouter');
 var competitionRouter = require('./routes/competitionRouter');
 
 var app = express();
@@ -49,6 +50,7 @@ app.use('/', usersRouter);
 app.use('/api', matchesRouter);
 app.use('/api', pitNavRouter);
 app.use('/api', pitFormRouter);
+app.use('/api', pickListsRouter);
 app.use('/', competitionRouter);
 
 // Anything that doesn't match the above, send back index.html

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,7 +4,7 @@ import TabNav from './components/TabNav';
 import PitContent from './components/PitContent';
 import MatchReportList from './components/MatchReportList';
 import SuperScoutContent from './components/SuperScoutContent';
-import AnalystContent from './components/AnalystContent';
+import TeamPickList from './components/TeamPickList';
 import Login from './components/Login';
 import Logout from './components/Logout';
 import {
@@ -135,7 +135,6 @@ class App extends Component {
           exact
           component={SuperScoutContent}
         />
-        <ProtectedRoute path='/analystHome' component={AnalystContent} />
         <ProtectedRoute
           path='/pits/:competition/:team'
           exact
@@ -151,6 +150,11 @@ class App extends Component {
           exact
           path='/data/:competition/:team/:dataType(match|pit)?'
           component={Data}
+        />
+        <ProtectedRoute
+          exact
+          path='/teamPickList'
+          component={TeamPickList}
         />
         <Route path='/login' component={Login} />
         <Route path='/logout' component={Logout} />

--- a/client/src/components/TabNav.js
+++ b/client/src/components/TabNav.js
@@ -65,8 +65,8 @@ class TabNav extends Component {
           </Link>
         </Nav.Item>
         <Nav.Item>
-          <Link className='nav-link' to='/analystHome'>
-            Analyst
+          <Link className='nav-link' to='/teamPickList'>
+            Team Pick List
           </Link>
         </Nav.Item>
         {this.loginOrLogoutLink()}

--- a/client/src/components/TeamPickList.js
+++ b/client/src/components/TeamPickList.js
@@ -1,0 +1,171 @@
+import React, { Component } from 'react';
+import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
+import 'react-bootstrap-table2-filter/dist/react-bootstrap-table2-filter.min.css';
+import BootstrapTable from 'react-bootstrap-table-next';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import { AuthContext } from '../contexts/auth_context';
+
+class TeamPickList extends Component {
+  static contextType = AuthContext;
+
+  state = {
+    competitions: [],
+    competition: '',
+    pickListResults: [],
+    defaultSort: [{
+      dataField: 'totalScore',
+      order: 'desc'
+    }],
+    columns: [
+      {
+        dataField: 'teamDescriptor',
+        text: 'Team'
+      },
+      {
+        dataField: 'autoScoredBottom',
+        text: 'Auto Scored Bottom',
+        sort: true
+      },
+      {
+        dataField: 'autoScoredOuter',
+        text: 'Auto Scored Outer',
+        sort: true
+      },
+      {
+        dataField: 'autoScoredInner',
+        text: 'Auto Scored Inner',
+        sort: true
+      },
+      {
+        dataField: 'teleopScoredBottom',
+        text: 'Teleop Scored Bottom',
+        sort: true
+      },
+      {
+        dataField: 'teleopScoredOuter',
+        text: 'Teleop Scored Outer',
+        sort: true
+      },
+      {
+        dataField: 'teleopScoredInner',
+        text: 'Teleop Scored Inner',
+        sort: true
+      },
+      {
+        dataField: 'penalties',
+        text: 'Penalties',
+        sort: true
+      },
+      {
+        dataField: 'yellowCard',
+        text: 'Yellow Card',
+        sort: true
+      },
+      {
+        dataField: 'redCard',
+        text: 'Red Card',
+        sort: true
+      },
+      {
+        dataField: 'totalScore',
+        text: 'Total Score',
+        sort: true,
+      }
+    ]
+  }
+
+  computeTotalScore(result) {
+    const formula = [
+      {
+        dataField: 'autoScoredBottom',
+        weight: 2
+      },
+      {
+        dataField: 'autoScoredOuter',
+        weight: 2.5
+      },
+      {
+        dataField: 'autoScoredInner',
+        weight: 3
+      },
+      {
+        dataField: 'teleopScoredBottom',
+        weight: 1
+      },
+      {
+        dataField: 'teleopScoredOuter',
+        weight: 1.5
+      },
+      {
+        dataField: 'teleopScoredInner',
+        weight: 2
+      },
+      {
+        dataField: 'penalties',
+        weight: -1
+      },
+      {
+        dataField: 'yellowCard',
+        weight: -10
+      },
+      {
+        dataField: 'redCard',
+        weight: -20
+      }
+    ]
+
+    return formula.reduce((acc, value) => {
+      return acc + (result[value.dataField] * value.weight);
+    }, 0)
+  }
+
+  componentDidMount() {
+    fetch('/competitions')
+      .then(response => response.json())
+      .then(data => {
+        this.setState({ competitions: data.competitions });
+        data.competitions.map(c => {
+          if (c.iscurrent) {
+            this.setState({ competition: c.shortname });
+          }
+        });
+      }).then(() => {
+        fetch(`/api/competitions/${this.state.competition}/pickLists/teams`)
+          .then(response => response.json())
+          .then((data) => {
+            data.forEach((result) => {
+              result.totalScore = this.computeTotalScore(result)
+            });
+            this.setState({
+              pickListResults: data
+            })
+          });
+      });
+  }
+
+  render() {
+    return (
+      <Container>
+        <Row>
+          <p>Competition: {this.state.competition}</p>
+        </Row>
+        <Row>
+          <BootstrapTable
+            striped
+            hover
+            keyField='teamId'
+            bordered
+            bootstrap4
+            data={this.state.pickListResults}
+            columns={this.state.columns}
+            defaultSorted={this.state.defaultSort}
+          />
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default TeamPickList;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,9 +2048,9 @@
       }
     },
     "react-bootstrap-table-next": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/react-bootstrap-table-next/-/react-bootstrap-table-next-3.3.4.tgz",
-      "integrity": "sha512-wtorv98pAPkRlVPR0NmPQIfSvPhP+zITXArGdyB0PJfXbHcGeSoMvtLTmXJYftusVJw/rLKbSkyrytgDEt2ibQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-table-next/-/react-bootstrap-table-next-3.3.5.tgz",
+      "integrity": "sha512-vBO+y2Y483Y1QnpxvgY8jTz6gwIPYpfc26AKZhwgESL6cpjhxSsoFGXNp3KKnT5krW5SF9zpcf/98jIJefv+RQ==",
       "requires": {
         "classnames": "^2.2.5",
         "react-transition-group": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "passport-local": "^1.0.0",
     "pg": "^7.17.1",
     "pug": "^2.0.4",
-    "react-bootstrap-table-next": "^3.3.3",
+    "react-bootstrap-table-next": "^3.3.5",
     "react-bootstrap-table2-filter": "^1.3.0",
     "react-html5-camera-photo": "^1.5.4",
     "react-router-dom": "^5.1.2",

--- a/routes/pickListsRouter.js
+++ b/routes/pickListsRouter.js
@@ -1,0 +1,34 @@
+var express = require('express');
+var router = express.Router();
+
+const db = require('../db');
+
+router.get('/competitions/:competitionName/pickLists/teams', (req, res) => {
+  const getTeamsForCompetitionPickListQuery = 'SELECT m.auto_scored, m.teleop_scored, m.negatives, t.team_id, t.team_num, t.team_name FROM match m INNER JOIN comp_team_mapping ctm ON ctm.mapping_id = m.mapping_id INNER JOIN team t on t.team_id = ctm.team_id INNER JOIN competition c ON c.competition_id = ctm.competition_id WHERE c.is_current = true';
+  const getTeamsForCompetitionPickListParams = [];
+
+  db.query(getTeamsForCompetitionPickListQuery, getTeamsForCompetitionPickListParams)
+    .then((data) => {
+      const mappedRows = data.rows.map((row) => {
+        return {
+          teamId: row.team_id,
+          teamDescriptor: `${row.team_num}: ${row.team_name}`,
+          autoScoredBottom: row.auto_scored.find(score => score.label == 'Bottom').value,
+          autoScoredOuter: row.auto_scored.find(score => score.label == 'Outer').value,
+          autoScoredInner: row.auto_scored.find(score => score.label == 'Inner').value,
+          teleopScoredBottom: row.teleop_scored.find(score => score.label == 'Bottom').value,
+          teleopScoredOuter: row.teleop_scored.find(score => score.label == 'Outer').value,
+          teleopScoredInner: row.teleop_scored.find(score => score.label == 'Inner').value,
+          penalties: row.negatives.find(negative => negative.label == 'Penalties').value,
+          yellowCard: row.negatives.find(negative => negative.label == 'Yellow Card').value,
+          redCard: row.negatives.find(negative => negative.label == 'Red Card').value
+        }
+      });
+      res.json(mappedRows);
+    })
+    .catch((e) => {
+      console.error(e.stack)
+    });
+});
+
+module.exports = router;


### PR DESCRIPTION
This is a first pass at "Team" Pick Lists for #33 . It operates under the impression that each team only has one match per competition, but if that's not an accurate assumption let me know and I can aggregate/combine the data for all the matches for a particular team. The page also defaults to using data from the is_current competition, though I don't know if we want to make that Competition Picker dropdown from the MatchReportList component a more generic reusable component and use that in more places so you can generate Pick Lists for any competition and not just the current...

Right now the score is generated from six positive metrics (3 metrics for auto score, 3 metrics for teleop scored) and 3 negative metrics (penalties, yellow card, and red card). There's a formula variable in the TeamPickList that computes a total score by extracting those metrics and multiplying them by a weight (or a negative weight in the case of the negative metrics)... It should be easy to add/remove data fields (assuming they are in the API) and to change the weights there. The table is sorted by Total Score by default, but all the columns support sorting as well.

Some of the data modeling makes this a little bit messier, things like `cross_line` being `varchar` with Yes/No instead of a bolean, and more particularly the JSON columns being structured as arrays of objects instead of objects. Because columns like `auto_scored` are stored as:

```json
[
  { "id": 1, "label": "Bottom", "value": 3 },
  { "id": 2, "label": "Outer", "value": 1 },
  { "id": 3, "label": "Inner", "value": 4 }
]
```

Instead of:

```json
{
  "bottom": { "value": 3 },
  "outer": { "value": 1 },
  "inner": { "value": 4 }
}
```
We end up having to do some processing to say "auto scored bottom is the element in the auto_scored array that has the label 'bottom'" and end up iterating over the array to find it. This limits our flexibility to do analysis/aggregation at the DB level, since we're not able to use Postgres' JSON syntax as easily... If it was stored in the latter format, you could do things like `SELECT auto_scored->bottom->>'value' AS auto_scored_bottom FROM match` instead of having to `SELECT auto_scored FROM match` and then parse it in Javascript.

Anyway, it doesn't matter too much now since the processing/analysis is simple, and we probably won't want to drastically change our data structure right before competitions, but just an idea for the future.
